### PR TITLE
Faster implementation of stl_math

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ The following general libraries are provided in this distribution. These are lib
     - `stl_bit_or()`: Return the bitwise OR of the inputs as an Integer.
     - `stl_bit_xor()`: Return the bitwise XOR of the inputs as an Integer.
 
+* `fstl_math.dnh` [Dependencies: None]
+    - `fstl_bit_not()`: Return the bitwise NOT of the input as an Integer.
+    - `fstl_lshift()`: Return the input left shifted n times.
+    - `fstl_rshift()`: Return the input right shifted n times.
+    - `fstl_bit_and()`: Return the bitwise AND of the inputs as an Integer.
+    - `fstl_bit_and_arr()`: Return the bitwise AND of the values of the input array as an Integer.
+    - `fstl_bit_or()`: Return the bitwise OR of the inputs as an Integer.
+    - `fstl_bit_or_arr()`: Return the bitwise OR of the values of the input array as an Integer.
+    - `fstl_bit_xor()`: Return the bitwise XOR of the inputs as an Integer.
+    - `fstl_any_zero()`: Returns true if any of the values in the input array is 0.
+    - `fstl_all_zero()`: Returns true if all of the values in the input array are 0.
+
 The following data structure libraries are provided in this distribution. These are data structure libraries custom-made for the STL distribution.
 
 * `stl_queue.dnh`

--- a/fstl_math.dnh
+++ b/fstl_math.dnh
@@ -82,8 +82,8 @@ function fstl_rshift(e, n) {
 function fstl_bit_and(e1, e2) {
     let byteVal = 1;
     let output = 0;
-    while (e1 > 0 || e2 > 0) {
-        if (e1 % 2 > 0 && e2 % 2 > 0) {
+    while (e1 + e2 > 0) {
+        if ((e1 % 2) + (e2 % 2) == 2) {
             output += byteVal;
         }
         e1 = floor(e1 / 2);
@@ -127,8 +127,8 @@ function fstl_bit_and_arr(arr) {
 function fstl_bit_or(e1, e2) {
     let byteVal = 1;
     let output = 0;
-    while (e1 > 0 || e2 > 0) {
-        if (e1 % 2 > 0 || e2 % 2 > 0) {
+    while (e1 + e2 > 0) {
+        if ((e1 % 2) + (e2 % 2) > 0) {
             output += byteVal;
         }
         e1 = floor(e1 / 2);
@@ -170,8 +170,8 @@ function fstl_bit_or_arr(arr) {
 function fstl_bit_xor(e1, e2) {
     let byteVal = 1;
     let output = 0;
-    while (e1 > 0 || e2 > 0) {
-        if ((e1 % 2 > 0) != (e2 % 2 > 0)) {
+    while (e1 + e2 > 0) {
+        if ((e1 % 2) != (e2 % 2)) {
             output += byteVal;
         }
         e1 = floor(e1 / 2);

--- a/fstl_math.dnh
+++ b/fstl_math.dnh
@@ -1,0 +1,212 @@
+/* ******************************************************************
+* Falsepattern's FastMath Library
+* For use with Touhou Danmakufu ph3
+* (C) FalsePattern 2019
+*
+* Code in this library is under the MIT License and may be 
+* redistributed/modified without express permission
+****************************************************************** */
+
+/* ******************************************************************
+* This library contains e1 variety of mathematical operators and functions
+* For speed, this library only contains 'unsafe' versions of operations
+* Functions in this library work on Integers (e.g. 5)
+* Compared to fstl_math, this one does not operate on binary strings,
+* but rather direcly with integers. Negative and decimal numbers
+* cause undefined behaviour. It is up to the user to pass in valid values
+* 
+* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+* !DOES NOT WORK WITH NEGATIVE VALUES!
+* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+* Notes:
+* there isn't any integer validation for maximum speed
+* the f in fstl stands for Fast
+****************************************************************** */
+
+/* ******************************************************************
+* Functions:
+* fstl_bit_not()
+* fstl_lshift()
+* fstl_rshift()
+* fstl_bit_and()
+* fstl_bit_and_arr()
+* fstl_bit_or()
+* fstl_bit_or_arr()
+* fstl_bit_xor()
+* fstl_any_zero()
+* fstl_all_zero()
+************************************************************************* */
+
+
+/* *************************************************************************
+* fstl_bit_not() -- Return the bitwise NOT of the input as an Integer.
+* Param: e (int) - Value to obtain bitwise NOT of
+* Return: Bitwise NOT of e
+************************************************************************* */
+function fstl_bit_not(e) {
+  return -e - 1;
+}
+
+/* *************************************************************************
+* fstl_lshift() -- Return the input left shifted n times.
+* Param: e (int) - Value to left shift
+* Param: n (int) - Number of times to left shift
+* Return: e << n
+************************************************************************* */
+function fstl_lshift(e, n) {
+  ascent(i in 0 .. n) {
+    e *= 2;
+  }
+  return e;
+}
+
+/* *************************************************************************
+* fstl_rshift() -- Return the input right shifted n times.
+* Param: e (int) - Value to right shift
+* Param: n (int) - Number of times to right shift
+* Return: e >> n
+************************************************************************* */
+function fstl_rshift(e, n) {
+  ascent(i in 0 .. n) {
+    e /= 2;
+  }
+  return truncate(e);
+}
+
+/* *************************************************************************
+* fstl_bit_and() -- Return the bitwise AND of the inputs as an Integer.
+* Param: e1 (int) - Value to obtain bitwise AND of
+* Param: e2 (int) - Value to obtain bitwise AND of
+* Return: Bitwise AND of e1 and e2
+************************************************************************* */
+function fstl_bit_and(e1, e2) {
+  let byteVal = 1;
+  let output = 0;
+  while (e1 > 0 || e2 > 0) {
+    if (e1 % 2 > 0 && e2 % 2 > 0) {
+      output += byteVal;
+    }
+    e1 = floor(e1 / 2);
+    e2 = floor(e2 / 2);
+    byteVal *= 2;
+  }
+  return output;
+}
+
+
+/* *************************************************************************
+* fstl_bit_and_arr() -- Return the bitwise AND of the inputs as an Integer.
+* Param: arr (array of ints) - Values to obtain bitwise AND of
+* Return: Bitwise AND of arr[0] ... arr[n] (n is length(arr) - 1)
+************************************************************************* */
+function fstl_bit_and_arr(arr) {
+  let byteVal = 1;
+  let output = 0;
+  let len = length(arr);
+  while (!fstl_all_zero(arr)) {
+    let bit = 1;
+    ascent(i in 0..len) {
+      if (arr[i] % 2 == 0) {
+        bit = 0;
+      }
+      arr[i] = floor(arr[i] / 2);
+    }
+    output += bit * byteVal;
+    byteVal *= 2;
+  }
+  return output;
+}
+
+
+/* *************************************************************************
+* fstl_bit_or() -- Return the bitwise OR of the inputs as an Integer.
+* Param: e1 (int) - Value to obtain bitwise OR of
+* Param: e2 (int) - Value to obtain bitwise OR of
+* Return: Bitwise OR of e1 and e2
+************************************************************************* */
+function fstl_bit_or(e1, e2) {
+  let byteVal = 1;
+  let output = 0;
+  while (e1 > 0 || e2 > 0) {
+    if (e1 % 2 > 0 || e2 % 2 > 0) {
+      output += byteVal;
+    }
+    e1 = floor(e1 / 2);
+    e2 = floor(e2 / 2);
+    byteVal *= 2;
+  }
+  return output;
+}
+
+/* *************************************************************************
+* fstl_bit_or_arr() -- Return the bitwise OR of the inputs as an Integer.
+* Param: arr (array of ints) - Values to obtain bitwise OR of
+* Return: Bitwise OR of arr[0] ... arr[n] (n is length(arr) - 1)
+************************************************************************* */
+function fstl_bit_or_arr(arr) {
+  let byteVal = 1;
+  let output = 0;
+  let len = length(arr);
+  while (!fstl_all_zero(arr)) {
+    let bit = 0;
+    ascent(i in 0..len) {
+      if (arr[i] % 2 > 0) {
+        bit = 1;
+      }
+      arr[i] = floor(arr[i] / 2);
+    }
+    output += bit * byteVal;
+    byteVal *= 2;
+  }
+  return output;
+}
+
+/* *************************************************************************
+* fstl_bit_xor() -- Return the bitwise XOR of the inputs as an Integer.
+* Param: e1 (int) - Value to obtain bitwise XOR of
+* Param: e2 (int) - Value to obtain bitwise XOR of
+* Return: Bitwise XOR of e1 and e2
+************************************************************************* */
+function fstl_bit_xor(e1, e2) {
+  let byteVal = 1;
+  let output = 0;
+  while (e1 > 0 || e2 > 0) {
+    if ((e1 % 2 > 0) != (e2 % 2 > 0)) {
+      output += byteVal;
+    }
+    e1 = floor(e1 / 2);
+    e2 = floor(e2 / 2);
+    byteVal *= 2;
+  }
+  return output;
+}
+
+/* *************************************************************************
+* fstl_bit_xor() -- Check whether any of the values in the array is 0
+* Param: arr (array of ints) - Values to check
+* Return: true if any of the array values is 0, false if none of them is 0
+************************************************************************* */
+function fstl_any_zero(arr) {
+  let len = length(arr);
+  ascent(i in 0..len) {
+    if (arr[i] == 0) {
+        return true;
+    }
+  }
+  return false;
+}
+
+/* *************************************************************************
+* fstl_bit_xor() -- Check whether all of the values in the array is 0
+* Param: arr (array of ints) - Values to check
+* Return: true if all of the array values is 0, false if any of them is not 0
+************************************************************************* */
+function fstl_all_zero(arr) {
+  let len = length(arr);
+  ascent(i in 0..len) {
+    if (arr[i] != 0) {
+        return false;
+    }
+  }
+  return true;
+}

--- a/fstl_math.dnh
+++ b/fstl_math.dnh
@@ -8,10 +8,10 @@
 ****************************************************************** */
 
 /* ******************************************************************
-* This library contains e1 variety of mathematical operators and functions
+* This library contains bitwise operators and functions
 * For speed, this library only contains 'unsafe' versions of operations
 * Functions in this library work on Integers (e.g. 5)
-* Compared to fstl_math, this one does not operate on binary strings,
+* Compared to stl_math, this one does not operate on binary strings,
 * but rather direcly with integers. Negative and decimal numbers
 * cause undefined behaviour. It is up to the user to pass in valid values
 * 

--- a/fstl_math.dnh
+++ b/fstl_math.dnh
@@ -182,7 +182,7 @@ function fstl_bit_xor(e1, e2) {
 }
 
 /* *************************************************************************
-* fstl_bit_xor() -- Check whether any of the values in the array is 0
+* fstl_any_zero() -- Check whether any of the values in the array is 0
 * Param: arr (array of ints) - Values to check
 * Return: true if any of the array values is 0, false if none of them is 0
 ************************************************************************* */
@@ -197,7 +197,7 @@ function fstl_any_zero(arr) {
 }
 
 /* *************************************************************************
-* fstl_bit_xor() -- Check whether all of the values in the array is 0
+* fstl_all_zero() -- Check whether all of the values in the array is 0
 * Param: arr (array of ints) - Values to check
 * Return: true if all of the array values is 0, false if any of them is not 0
 ************************************************************************* */

--- a/fstl_math.dnh
+++ b/fstl_math.dnh
@@ -44,7 +44,7 @@
 * Return: Bitwise NOT of e
 ************************************************************************* */
 function fstl_bit_not(e) {
-  return -e - 1;
+    return -e - 1;
 }
 
 /* *************************************************************************
@@ -54,10 +54,10 @@ function fstl_bit_not(e) {
 * Return: e << n
 ************************************************************************* */
 function fstl_lshift(e, n) {
-  ascent(i in 0 .. n) {
-    e *= 2;
-  }
-  return e;
+    ascent(i in 0 .. n) {
+        e *= 2;
+    }
+    return e;
 }
 
 /* *************************************************************************
@@ -67,10 +67,10 @@ function fstl_lshift(e, n) {
 * Return: e >> n
 ************************************************************************* */
 function fstl_rshift(e, n) {
-  ascent(i in 0 .. n) {
-    e /= 2;
-  }
-  return truncate(e);
+    ascent(i in 0 .. n) {
+        e /= 2;
+    }
+    return truncate(e);
 }
 
 /* *************************************************************************
@@ -80,17 +80,17 @@ function fstl_rshift(e, n) {
 * Return: Bitwise AND of e1 and e2
 ************************************************************************* */
 function fstl_bit_and(e1, e2) {
-  let byteVal = 1;
-  let output = 0;
-  while (e1 > 0 || e2 > 0) {
-    if (e1 % 2 > 0 && e2 % 2 > 0) {
-      output += byteVal;
+    let byteVal = 1;
+    let output = 0;
+    while (e1 > 0 || e2 > 0) {
+        if (e1 % 2 > 0 && e2 % 2 > 0) {
+            output += byteVal;
+        }
+        e1 = floor(e1 / 2);
+        e2 = floor(e2 / 2);
+        byteVal *= 2;
     }
-    e1 = floor(e1 / 2);
-    e2 = floor(e2 / 2);
-    byteVal *= 2;
-  }
-  return output;
+    return output;
 }
 
 
@@ -100,21 +100,21 @@ function fstl_bit_and(e1, e2) {
 * Return: Bitwise AND of arr[0] ... arr[n] (n is length(arr) - 1)
 ************************************************************************* */
 function fstl_bit_and_arr(arr) {
-  let byteVal = 1;
-  let output = 0;
-  let len = length(arr);
-  while (!fstl_all_zero(arr)) {
-    let bit = 1;
-    ascent(i in 0..len) {
-      if (arr[i] % 2 == 0) {
-        bit = 0;
-      }
-      arr[i] = floor(arr[i] / 2);
+    let byteVal = 1;
+    let output = 0;
+    let len = length(arr);
+    while (!fstl_all_zero(arr)) {
+        let bit = 1;
+        ascent(i in 0..len) {
+            if (arr[i] % 2 == 0) {
+                bit = 0;
+            }
+            arr[i] = floor(arr[i] / 2);
+        }
+        output += bit * byteVal;
+        byteVal *= 2;
     }
-    output += bit * byteVal;
-    byteVal *= 2;
-  }
-  return output;
+    return output;
 }
 
 
@@ -125,17 +125,17 @@ function fstl_bit_and_arr(arr) {
 * Return: Bitwise OR of e1 and e2
 ************************************************************************* */
 function fstl_bit_or(e1, e2) {
-  let byteVal = 1;
-  let output = 0;
-  while (e1 > 0 || e2 > 0) {
-    if (e1 % 2 > 0 || e2 % 2 > 0) {
-      output += byteVal;
+    let byteVal = 1;
+    let output = 0;
+    while (e1 > 0 || e2 > 0) {
+        if (e1 % 2 > 0 || e2 % 2 > 0) {
+            output += byteVal;
+        }
+        e1 = floor(e1 / 2);
+        e2 = floor(e2 / 2);
+        byteVal *= 2;
     }
-    e1 = floor(e1 / 2);
-    e2 = floor(e2 / 2);
-    byteVal *= 2;
-  }
-  return output;
+    return output;
 }
 
 /* *************************************************************************
@@ -144,21 +144,21 @@ function fstl_bit_or(e1, e2) {
 * Return: Bitwise OR of arr[0] ... arr[n] (n is length(arr) - 1)
 ************************************************************************* */
 function fstl_bit_or_arr(arr) {
-  let byteVal = 1;
-  let output = 0;
-  let len = length(arr);
-  while (!fstl_all_zero(arr)) {
-    let bit = 0;
-    ascent(i in 0..len) {
-      if (arr[i] % 2 > 0) {
-        bit = 1;
-      }
-      arr[i] = floor(arr[i] / 2);
+    let byteVal = 1;
+    let output = 0;
+    let len = length(arr);
+    while (!fstl_all_zero(arr)) {
+        let bit = 0;
+        ascent(i in 0..len) {
+            if (arr[i] % 2 > 0) {
+                bit = 1;
+            }
+            arr[i] = floor(arr[i] / 2);
+        }
+        output += bit * byteVal;
+        byteVal *= 2;
     }
-    output += bit * byteVal;
-    byteVal *= 2;
-  }
-  return output;
+    return output;
 }
 
 /* *************************************************************************
@@ -168,17 +168,17 @@ function fstl_bit_or_arr(arr) {
 * Return: Bitwise XOR of e1 and e2
 ************************************************************************* */
 function fstl_bit_xor(e1, e2) {
-  let byteVal = 1;
-  let output = 0;
-  while (e1 > 0 || e2 > 0) {
-    if ((e1 % 2 > 0) != (e2 % 2 > 0)) {
-      output += byteVal;
+    let byteVal = 1;
+    let output = 0;
+    while (e1 > 0 || e2 > 0) {
+        if ((e1 % 2 > 0) != (e2 % 2 > 0)) {
+            output += byteVal;
+        }
+        e1 = floor(e1 / 2);
+        e2 = floor(e2 / 2);
+        byteVal *= 2;
     }
-    e1 = floor(e1 / 2);
-    e2 = floor(e2 / 2);
-    byteVal *= 2;
-  }
-  return output;
+    return output;
 }
 
 /* *************************************************************************
@@ -187,13 +187,13 @@ function fstl_bit_xor(e1, e2) {
 * Return: true if any of the array values is 0, false if none of them is 0
 ************************************************************************* */
 function fstl_any_zero(arr) {
-  let len = length(arr);
-  ascent(i in 0..len) {
-    if (arr[i] == 0) {
-        return true;
+    let len = length(arr);
+    ascent(i in 0..len) {
+        if (arr[i] == 0) {
+            return true;
+        }
     }
-  }
-  return false;
+    return false;
 }
 
 /* *************************************************************************
@@ -202,11 +202,11 @@ function fstl_any_zero(arr) {
 * Return: true if all of the array values is 0, false if any of them is not 0
 ************************************************************************* */
 function fstl_all_zero(arr) {
-  let len = length(arr);
-  ascent(i in 0..len) {
-    if (arr[i] != 0) {
-        return false;
+    let len = length(arr);
+    ascent(i in 0..len) {
+        if (arr[i] != 0) {
+                return false;
+        }
     }
-  }
-  return true;
+    return true;
 }

--- a/test/fstl_math_test.dnh
+++ b/test/fstl_math_test.dnh
@@ -7,14 +7,14 @@
 #include "./../fstl_math.dnh"
 
 @Initialize {
-  BitNotTest;
-  LShiftTest;
-  RShiftTest;
-  BitAndTest;
-  BitAndArrTest;
-  BitOrTest;
-  BitOrArrTest;
-  BitXorTest;
+    BitNotTest;
+    LShiftTest;
+    RShiftTest;
+    BitAndTest;
+    BitAndArrTest;
+    BitOrTest;
+    BitOrArrTest;
+    BitXorTest;
 }
 
 @MainLoop {
@@ -22,69 +22,69 @@
 }
 
 task BitNotTest {
-  ascent (i in -128 .. 128) {
-    DoTestA(stl_bit_not(i), fstl_bit_not(i), i, "fstl_bit_not");
-  }
+    ascent (i in -128 .. 128) {
+        DoTestA(stl_bit_not(i), fstl_bit_not(i), i, "fstl_bit_not");
+    }
 }
 
 task LShiftTest {
-  ascent(i in 0 .. 32) {
-    ascent(j in -1024 .. 1024) {
-      DoTestB(stl_lshift(j, i), fstl_lshift(j, i), j, i, "fstl_lshift");
+    ascent(i in 0 .. 32) {
+        ascent(j in -1024 .. 1024) {
+            DoTestB(stl_lshift(j, i), fstl_lshift(j, i), j, i, "fstl_lshift");
+        }
     }
-  }
 }
 
 task RShiftTest {
-  ascent(i in 0 .. 32) {
-    ascent(j in -1024 .. 1024) {
-      DoTestB(stl_rshift(j, i), fstl_rshift(j, i), j, i, "fstl_rshift");
+    ascent(i in 0 .. 32) {
+        ascent(j in -1024 .. 1024) {
+            DoTestB(stl_rshift(j, i), fstl_rshift(j, i), j, i, "fstl_rshift");
+        }
     }
-  }
 }
 
 task BitAndTest {
-  ascent(i in 0 .. 256) {
-    ascent(j in 0 .. 256) {
-      DoTestB(stl_bit_and(i, j), fstl_bit_and(i, j), i, j, "fstl_bit_and");
+    ascent(i in 0 .. 256) {
+        ascent(j in 0 .. 256) {
+            DoTestB(stl_bit_and(i, j), fstl_bit_and(i, j), i, j, "fstl_bit_and");
+        }
     }
-  }
 }
 
 task BitAndArrTest {
-  ascent(i in 0 .. 32) {
-    ascent(j in 0 .. 32) {
-      ascent(k in 0 .. 32) {
-      DoTestArr(fstl_bit_and(fstl_bit_and(i, j), k), fstl_bit_and_arr([i, j, k]), i, j, k, "fstl_bit_and_arr");
-      }
+    ascent(i in 0 .. 32) {
+        ascent(j in 0 .. 32) {
+            ascent(k in 0 .. 32) {
+                DoTestArr(fstl_bit_and(fstl_bit_and(i, j), k), fstl_bit_and_arr([i, j, k]), i, j, k, "fstl_bit_and_arr");
+            }
+        }
     }
-  }
 }
 
 task BitOrTest {
-  ascent(i in 0 .. 256) {
-    ascent(j in 0 .. 256) {
-      DoTestB(stl_bit_or(i, j), fstl_bit_or(i, j), i, j, "fstl_bit_or");
+    ascent(i in 0 .. 256) {
+        ascent(j in 0 .. 256) {
+            DoTestB(stl_bit_or(i, j), fstl_bit_or(i, j), i, j, "fstl_bit_or");
+        }
     }
-  }
 }
 
 task BitOrArrTest {
-  ascent(i in 0 .. 32) {
-    ascent(j in 0 .. 32) {
-      ascent(k in 0 .. 32) {
-      DoTestArr(fstl_bit_or(fstl_bit_or(i, j), k), fstl_bit_or_arr([i, j, k]), i, j, k, "fstl_bit_or_arr");
-      }
+    ascent(i in 0 .. 32) {
+        ascent(j in 0 .. 32) {
+            ascent(k in 0 .. 32) {
+                DoTestArr(fstl_bit_or(fstl_bit_or(i, j), k), fstl_bit_or_arr([i, j, k]), i, j, k, "fstl_bit_or_arr");
+            }
+        }
     }
-  }
 }
 
 task BitXorTest {
-  ascent(i in 0 .. 256) {
-    ascent(j in 0 .. 256) {
-      DoTestB(stl_bit_xor(i, j), fstl_bit_xor(i, j), i, j, "fstl_bit_xor");
+    ascent(i in 0 .. 256) {
+        ascent(j in 0 .. 256) {
+            DoTestB(stl_bit_xor(i, j), fstl_bit_xor(i, j), i, j, "fstl_bit_xor");
+        }
     }
-  }
 }
 
 /*
@@ -93,17 +93,19 @@ task BitXorTest {
 * only builds the string when an inequality occurs.
 */
 function DoTestA(stlValue, fstlValue, inputValueA, functionName) {
-  if (stlValue == fstlValue) {return;} else {
-    RaiseError(functionName ~ " error! STL result: " ~ itoa(stlValue) ~ ", FSTL result: " ~ itoa(fstlValue) ~ ", at value " ~ itoa(inputValueA));
-  }
+    if (stlValue == fstlValue) {return;} else {
+        RaiseError(functionName ~ " error! STL result: " ~ itoa(stlValue) ~ ", FSTL result: " ~ itoa(fstlValue) ~ ", at value " ~ itoa(inputValueA));
+    }
 }
+
 function DoTestB(stlValue, fstlValue, inputValueA, inputValueB, functionName) {
-  if (stlValue == fstlValue) {return;} else {
-    RaiseError(functionName ~ " error! STL result: " ~ itoa(stlValue) ~ ", FSTL result: " ~ itoa(fstlValue) ~ ", at values A:" ~ itoa(inputValueA) ~ ", B:" ~ itoa(inputValueB));
-  }
+    if (stlValue == fstlValue) {return;} else {
+        RaiseError(functionName ~ " error! STL result: " ~ itoa(stlValue) ~ ", FSTL result: " ~ itoa(fstlValue) ~ ", at values A:" ~ itoa(inputValueA) ~ ", B:" ~ itoa(inputValueB));
+    }
 }
+
 function DoTestArr(stlValue, fstlValue, inputValueA, inputValueB, inputValueC, functionName) {
-  if (stlValue == fstlValue) {return;} else {
-    RaiseError(functionName ~ " error! FSTL result: " ~ itoa(stlValue) ~ ", FSTL_ARR result: " ~ itoa(fstlValue) ~ ", at values A:" ~ itoa(inputValueA) ~ ", B:" ~ itoa(inputValueB) ~ ", C:" ~ itoa(inputValueC));
-  }
+    if (stlValue == fstlValue) {return;} else {
+        RaiseError(functionName ~ " error! FSTL result: " ~ itoa(stlValue) ~ ", FSTL_ARR result: " ~ itoa(fstlValue) ~ ", at values A:" ~ itoa(inputValueA) ~ ", B:" ~ itoa(inputValueB) ~ ", C:" ~ itoa(inputValueC));
+    }
 }

--- a/test/fstl_math_test.dnh
+++ b/test/fstl_math_test.dnh
@@ -1,0 +1,109 @@
+#TouhouDanmakufu[Stage]
+#Title["FSTL Math Test"]
+#Text["Unit Testing for fstl_math.dnh[r]Test stl_math.dnh first![r]This test compares the FSTL[r] implementation to the[r] STL implementation!"]
+#ScriptVersion[3]
+
+#include "./../stl_math.dnh"
+#include "./../fstl_math.dnh"
+
+@Initialize {
+  BitNotTest;
+  LShiftTest;
+  RShiftTest;
+  BitAndTest;
+  BitAndArrTest;
+  BitOrTest;
+  BitOrArrTest;
+  BitXorTest;
+}
+
+@MainLoop {
+    yield;
+}
+
+task BitNotTest {
+  ascent (i in -128 .. 128) {
+    DoTestA(stl_bit_not(i), fstl_bit_not(i), i, "fstl_bit_not");
+  }
+}
+
+task LShiftTest {
+  ascent(i in 0 .. 32) {
+    ascent(j in -1024 .. 1024) {
+      DoTestB(stl_lshift(j, i), fstl_lshift(j, i), j, i, "fstl_lshift");
+    }
+  }
+}
+
+task RShiftTest {
+  ascent(i in 0 .. 32) {
+    ascent(j in -1024 .. 1024) {
+      DoTestB(stl_rshift(j, i), fstl_rshift(j, i), j, i, "fstl_rshift");
+    }
+  }
+}
+
+task BitAndTest {
+  ascent(i in 0 .. 256) {
+    ascent(j in 0 .. 256) {
+      DoTestB(stl_bit_and(i, j), fstl_bit_and(i, j), i, j, "fstl_bit_and");
+    }
+  }
+}
+
+task BitAndArrTest {
+  ascent(i in 0 .. 32) {
+    ascent(j in 0 .. 32) {
+      ascent(k in 0 .. 32) {
+      DoTestArr(fstl_bit_and(fstl_bit_and(i, j), k), fstl_bit_and_arr([i, j, k]), i, j, k, "fstl_bit_and_arr");
+      }
+    }
+  }
+}
+
+task BitOrTest {
+  ascent(i in 0 .. 256) {
+    ascent(j in 0 .. 256) {
+      DoTestB(stl_bit_or(i, j), fstl_bit_or(i, j), i, j, "fstl_bit_or");
+    }
+  }
+}
+
+task BitOrArrTest {
+  ascent(i in 0 .. 32) {
+    ascent(j in 0 .. 32) {
+      ascent(k in 0 .. 32) {
+      DoTestArr(fstl_bit_or(fstl_bit_or(i, j), k), fstl_bit_or_arr([i, j, k]), i, j, k, "fstl_bit_or_arr");
+      }
+    }
+  }
+}
+
+task BitXorTest {
+  ascent(i in 0 .. 256) {
+    ascent(j in 0 .. 256) {
+      DoTestB(stl_bit_xor(i, j), fstl_bit_xor(i, j), i, j, "fstl_bit_xor");
+    }
+  }
+}
+
+/*
+* We use if/else instead of assertions, because assert
+* always builds the error string, but the if/else RaiseError
+* only builds the string when an inequality occurs.
+*/
+function DoTestA(stlValue, fstlValue, inputValueA, functionName) {
+  if (stlValue == fstlValue) {return;} else {
+    RaiseError(functionName ~ " error! STL result: " ~ itoa(stlValue) ~ ", FSTL result: " ~ itoa(fstlValue) ~ ", at value " ~ itoa(inputValueA));
+  }
+}
+function DoTestB(stlValue, fstlValue, inputValueA, inputValueB, functionName) {
+  if (stlValue == fstlValue) {return;} else {
+    RaiseError(functionName ~ " error! STL result: " ~ itoa(stlValue) ~ ", FSTL result: " ~ itoa(fstlValue) ~ ", at values A:" ~ itoa(inputValueA) ~ ", B:" ~ itoa(inputValueB));
+  }
+}
+function DoTestArr(stlValue, fstlValue, inputValueA, inputValueB, inputValueC, functionName) {
+  if (stlValue == fstlValue) {return;} else {
+    RaiseError(functionName ~ " error! FSTL result: " ~ itoa(stlValue) ~ ", FSTL_ARR result: " ~ itoa(fstlValue) ~ ", at values A:" ~ itoa(inputValueA) ~ ", B:" ~ itoa(inputValueB) ~ ", C:" ~ itoa(inputValueC));
+  }
+}


### PR DESCRIPTION
This is an implementation of the stl_math library, which is considerably faster.
The main reason for the speed is that this library does not use binary strings, but directly operates on the integer values.

The core mechanism of this implementation:
The least significant bit of an integer can be retrieved like this:  lsb(x) -> x % 2
The next bit can be retrieved by first dividing the value by 2, flooring it, and then getting the new least significant bit.
Using this, we can directly compare two integers bit-by-bit by repeating the division + bit retrieval until both numbers are 0.

I have also provided a test, which compares the fstl_math library's results to the stl_math library's.
(because of the large amount of test cases, the game may hang for a minute before resuming)